### PR TITLE
Remove Dave's Free Press site

### DIFF
--- a/perlsphere.yaml
+++ b/perlsphere.yaml
@@ -23,7 +23,6 @@ plugins:
         - url:   http://szabgab.com/blog/Perl.rss
           title: Gabor Szabo
         - url:   http://feeds2.feedburner.com/DamienLearnsPerl
-        - url:   http://www.cantrell.org.uk/david/journal/index.pl/keyword_perl?format=rss
         - url:   http://leto.net/dukeleto.pl/atom.xml
         - url:   http://jquelin.blogspot.com/feeds/posts/default?alt=rss
           title: Jérôme Quelin


### PR DESCRIPTION
Every few weeks, we republish the same articles from over a decade ago (see #7). Don't know what's triggering it on that end, but enough.